### PR TITLE
Fix / Add simple example

### DIFF
--- a/examples/remote_example.py
+++ b/examples/remote_example.py
@@ -1,6 +1,17 @@
+"""Remote server example
+
+This examples shows how to send data to a server (a running RECAST3D
+process, for instance) running on a remote server.
+"""
 import tomop
 import numpy as np
 
+# The ports given below are the default ports. It is unlikely that you
+# want to change them. The remote host must be changed to run this
+# example.
+remote_host = "example.com"
+remote_port1 = 5555
+remote_port2 = 5556
 
 def callback(orientation, slice_id):
     print("callback called")
@@ -9,7 +20,11 @@ def callback(orientation, slice_id):
                              0, 0, 255, 255, 0, 0,
                              255], dtype='float32')
 
-serv = tomop.server("scene name")
+serv = tomop.server(
+    "scene name",
+    f"tcp://{remote_host}:{remote_port1}",
+    f"tcp://{remote_host}:{remote_port2}",
+)
 
 vdp = tomop.volume_data_packet(
     serv.scene_id(),


### PR DESCRIPTION
This commit

1) Fixes simple_example.py, so that it does not crash recast3d running
   on laptops with intel integrated graphics. See:
   https://github.com/cicwi/RECAST3D/pull/7
2) Adds an example where RECAST3D is not running on the same host as
   the example code itself.