### PR TITLE
Pin ZeroMQ to version 4.X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,9 @@ set(
 )
 
 # --------------------------------------------------------------------------------------------
-# ZeroMQ
+# ZeroMQ version 4.X
 if (NOT TARGET zmq)
-find_package(ZeroMQ QUIET)
+find_package(ZeroMQ 4 QUIET)
 
 if (ZeroMQ_FOUND)
     add_library(zmq INTERFACE)

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -28,10 +28,10 @@ requirements:
     - pip
     - boost-cpp
     - pybind11
-    - zeromq
+    - zeromq=4
   run:
     - python
-    - zeromq
+    - zeromq=4
 
 about:
   home: https://github.com/cicwi/TomoPackets


### PR DESCRIPTION
This pins the ZeroMQ dependency to version `4.X` as discussed in https://github.com/cicwi/RECAST3D/pull/8