### PR TITLE
Add Vectorfloat Python bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 - Add `Parameter{Bool,Float,Enum}Packet`, `TrackerPacket` and `BenchmarkPacket`.
 - Add support for `std::vector<std::string>` fields.
 
+### Changed
+- Changed `std::vector<float>` components to use `VectorFloat` in Python bindings (breaking).
+
 ## [1.0.0-rc2] - 2018-11-12
 
 ### Added

--- a/tomop/module.cpp
+++ b/tomop/module.cpp
@@ -1,7 +1,10 @@
 #include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
 namespace py = pybind11;
+
+PYBIND11_MAKE_OPAQUE(std::vector<float>);
 
 #include <tomop/tomop.hpp>
 
@@ -106,4 +109,6 @@ PYBIND11_MODULE(py_tomop, m) {
         .def(py::init<std::string, int32_t>())
         .def(py::init<std::string, int32_t, int32_t>())
         .def("send", &tomop::publisher::send);
+
+    py::bind_vector<std::vector<float>>(m, "VectorFloat", py::buffer_protocol());
 }


### PR DESCRIPTION
Changed `std::vector<float>` components to use `VectorFloat` in Python bindings to increase speed of data copy in Python adapter when making a tomopacket.